### PR TITLE
PRレビュー依頼タスクに変更統計情報を追加

### DIFF
--- a/src/repository/github.ts
+++ b/src/repository/github.ts
@@ -5,6 +5,9 @@ type GithubGetPR = {
   requested_reviewers: GithubGetReviewerNameResult[];
   title: string;
   html_url: string;
+  additions: number;
+  deletions: number;
+  changed_files: number;
 };
 
 type GithubGetReviewerNameResult = {

--- a/src/usecase.ts
+++ b/src/usecase.ts
@@ -62,7 +62,8 @@ export const execPrReviewRequestedMention = async (
     const prUrl = pr?.html_url;
     const prTitle = pr?.title;
 
-    const message = `[To:${account.account_id}] (bow) has been requested to review PR:${prTitle} ${prUrl} by ${requestUsername}.`;
+    const changesInfo = `+${pr.additions} -${pr.deletions}, ${pr.changed_files} files`;
+    const message = `[To:${account.account_id}] (bow) has been requested to review PR:${prTitle}\n${changesInfo}\n${prUrl} by ${requestUsername}.`;
     const { apiToken } = allInputs;
 
     const exist = await ChatworkRepositoryImpl.existChatworkTask(


### PR DESCRIPTION
## 概要
- PRレビュー依頼時のChatworkタスクメッセージに変更行数情報を追加
- 追加行数、削除行数、変更ファイル数を表示してレビュアーが変更規模を把握できるよう改善

## 変更内容
- `GithubGetPR`型に`additions`、`deletions`、`changed_files`フィールドを追加
- タスクメッセージのフォーマットを更新: `+X -Y, Zファイル` 形式で表示
- 変更情報を別行で表示し可読性を向上

## テスト
- [x] 既存テストが全て通過することを確認
- [x] ビルドが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)